### PR TITLE
FIXED: Small typo and missing parens in documentation, which caused error when running.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ state change then the plugin triggers a `fullscreenerror` event on the
 document. Example:
 
     $(document).bind("fullscreenchange", function() {
-        console.log("Fullscreen " + $(document).fullScreen() ? "on" : "off);
+        console.log("Fullscreen " + ($(document).fullScreen() ? "on" : "off"));
     });
 
     $(document).bind("fullscreenerror", function() {


### PR DESCRIPTION
A missing close quote within the 'fullscreenchange' event handler in the documentation code produced an error, and missing parentheses around the ternary seemed silently fail (it always logged "on", and not "Fullscreen on" or "Fullscreen off").
