### PR TITLE
Pass jQuery variable in to the setup function

### DIFF
--- a/jquery.fullscreen.js
+++ b/jquery.fullscreen.js
@@ -6,7 +6,7 @@
  * (See http://www.opensource.org/licenses/mit-license)
  */
  
-(function() {
+(function(jQuery) {
 
 /**
  * Sets or gets the fullscreen state.
@@ -181,4 +181,4 @@ jQuery.fn["fullScreen"] = fullScreen;
 jQuery.fn["toggleFullScreen"] = toggleFullScreen;
 installFullScreenHandlers();
 
-})();
+})(jQuery);


### PR DESCRIPTION
Pass the jQuery variable in to the setup function, this is necessary in environments where jQuery is removed from the window scope (via `jQuery.noConflict(true);`).